### PR TITLE
build: Bump ABI version to be newer than any "real" libudev.so.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 CFLAGS := -Wall -Wextra -g -fvisibility=hidden -shared -fPIC $(CFLAGS)
 LDFLAGS := -Wl,-soname,libudev.so.0 -Wl,-z,now $(LDFLAGS)
 LDLIBS := -ludev
+abi_version := 0.13.9999
 
 default: all
 
 all: \
-	libudev.so.0.0.9999
+	libudev.so.$(abi_version)
 
-libudev.so.0.0.9999: libudev0.c
+libudev.so.$(abi_version): libudev0.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
 clean:
-	$(RM) libudev.so.0.0.9999
+	$(RM) libudev.so.$(abi_version)


### PR DESCRIPTION
If we have a stale copy of udev's libudev.so.0 (from udev 182 or earlier) in the same directory as this shim, presumably we want the shim to compare as newer, so that ldconfig(8) will prefer to create a symlink libudev.so.0 -> libudev.so.0.x.y pointing to this shim.

To achieve that, the shim's ABI version number 0.x.y needs to be strictly newer than 0.13.1, which was the ABI version of udev 182, before the SONAME bump to libudev.so.1 in systemd 183.

Having versions compare in a correct order is also helpful for the Steam Runtime.

Resolves: https://github.com/archlinux/libudev0-shim/issues/4